### PR TITLE
Prefer `chronicler::pick()` in vignette

### DIFF
--- a/vignettes/real-world-example.Rmd
+++ b/vignettes/real-world-example.Rmd
@@ -29,6 +29,9 @@ library(tidyr)
 library(stringr)
 library(lubridate)
 
+# Ensure chronicler version of `pick()` is being used
+pick <- chronicler::pick
+
 data("avia")
 ```
 


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

dplyr 1.1.0 adds `pick()` as a pure selection variant to `across()`. Unfortunately this conflicts with a function in your package. I've worked around this in the vignette by ensuring your version of pick is always preferred (regardless of the installed version of dplyr).

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!