### PR TITLE
Added first version of record_ggplot()

### DIFF
--- a/R/chronicle.R
+++ b/R/chronicle.R
@@ -597,3 +597,49 @@ check_diff <- function(.c, columns = c("ops_number", "function")){
   as.data.frame(.c$log_df[, c(columns, "diff_obj")])
 
 }
+
+#' Helper function for record_ggplot
+#'
+#' @details
+#' ggplot_fun takes a ggplot_call (an unevaluated ggplot expression) as input
+#' and does the following steps:
+#' 1. Evaluates the ggplot_call using rlang::eval_tidy
+#' 2. Builds the ggplot object using ggplot2::ggplot_build
+#' 3. Returns the ggplot object
+#' @param ggplot_call An unevaluated ggplot expression.
+#' @return A ggplot object.
+#' @examples
+#' # This function is not meant to be used directly by the user.
+#' # Instead, use record_ggplot function.
+ggplot_fun <- function(ggplot_call) {
+  ggplot_obj <- rlang::eval_tidy(ggplot_call)
+  ggplot2::ggplot_build(ggplot_obj)
+  ggplot_obj
+}
+
+#' Record ggplot
+#'
+#' @details
+#' record_ggplot takes a ggplot_expression and an optional strict argument as input and does the following steps:
+#' 1. Captures the unevaluated ggplot_expression using substitute
+#' 2. Records the ggplot_fun function with the given strict argument using the record function from chronicler
+#' 3. Passes the captured ggplot_call to the recorded ggplot_fun function
+#' 4. Returns the result of the recorded ggplot_fun function
+#' @param ggplot_expression A ggplot expression.
+#' @param strict An optional integer argument controlling the behavior of the record() function from chronicler. Default is 2.
+#' @return A chronicler object.
+#' @examples
+#' # Unsuccessful example
+#' x <- record_ggplot(ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpgg)))
+#' print(x)
+#'
+#' # Successful example
+#' z <- record_ggplot(ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg)))
+#' print(z)
+#' @export
+record_ggplot <- function(ggplot_expression, strict = 2) {
+  ggplot_call <- substitute(ggplot_expression)
+  r_ggplot_fun <- record(ggplot_fun, strict = strict)
+  r_ggplot_fun(ggplot_call)
+}
+


### PR DESCRIPTION
Think documentation should be quite self-explanatory. :) I have created a function record_ggplot() because it seems like the functionality is quite different from the standard use cases of record(). 

In my opinion, there are two problems with using record() for ggplot: 
1)
This: 
a <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpgg))
Doesn't throw an error immediately, due to lazy evaluation. Only after e.g. print(a).
2)
Even if 1) threw an error immediately, we would still have to do something along the lines: 
r_ggplot <- record(ggplot)
r_geom_point <- record(geom_point)
r_aes <- record(aes)
and then:
a <- r_ggplot(data = mtcars) + r_geom_point(r_aes(y = hp, x = mpg))

Thats why I've created a separate function, record_ggplot().