### PR TITLE
Cleaner solution without global assignment

### DIFF
--- a/R/chronicle.R
+++ b/R/chronicle.R
@@ -614,8 +614,7 @@ check_diff <- function(.c, columns = c("ops_number", "function")){
 #' # This function is not meant to be used directly by the user.
 #' # Instead, use record_ggplot function.
 ggplot_fun <- function(ggplot_expression) {
-  ggplot_call <- substitute(ggplot_expression)
-  ggplot_obj <- eval_tidy(ggplot_call)
+  ggplot_obj <- eval_tidy(ggplot_expression)
   ggplot_build(ggplot_obj)
   return(ggplot_obj)
 }
@@ -641,7 +640,7 @@ ggplot_fun <- function(ggplot_expression) {
 #' print(z)
 #' @export
 record_ggplot <- function(ggplot_expression, strict = 2) {
-  # ggplot_call <- substitute(ggplot_expression)
+
   r_ggplot_fun <- record(ggplot_fun, strict = strict)
   r_ggplot_fun(ggplot_expression)
 }

--- a/R/chronicle.R
+++ b/R/chronicle.R
@@ -600,19 +600,21 @@ check_diff <- function(.c, columns = c("ops_number", "function")){
 
 #' Helper function for record_ggplot()
 #'
-#' @details
-#' ggplot_fun() takes a ggplot_call (an unevaluated ggplot expression) as input
+#' @description
+#' ggplot_fun() takes a ggplot_expression (an unevaluated ggplot expression) as input
 #' and does the following steps:
-#' 1. Evaluates the ggplot_call using rlang::eval_tidy
+#' 1. Evaluates the ggplot_expression using rlang::eval_tidy
 #' 2. Builds the ggplot object using ggplot2::ggplot_build
 #' 3. Returns the ggplot object
-#' @param ggplot_call An unevaluated ggplot expression.
+#' @param ggplot_expression An unevaluated ggplot expression.
 #' @return A ggplot object.
 #' @importFrom rlang eval_tidy
 #' @importFrom ggplot2 ggplot_build
 #' @examples
+#' \dontrun{
 #' # This function is not meant to be used directly by the user.
 #' # Instead, use record_ggplot function.
+#' }
 ggplot_fun <- function(ggplot_expression) {
 
   ggplot_obj <- eval_tidy(ggplot_expression)
@@ -623,12 +625,11 @@ ggplot_fun <- function(ggplot_expression) {
 
 #' Record ggplot
 #'
-#' @details
+#' @description
 #' record_ggplot takes a ggplot_expression and an optional strict argument as input and does the following steps:
-#' 1. Captures the unevaluated ggplot_expression using substitute
-#' 2. Records the ggplot_fun function with the given strict argument using the record function from chronicler
-#' 3. Passes the captured ggplot_call to the recorded ggplot_fun function
-#' 4. Returns the result of the recorded ggplot_fun function
+#' 1. Records the ggplot_fun function with the given strict argument using the record function from chronicler
+#' 2. Passes the ggplot_expression to the recorded ggplot_fun function
+#' 3. Returns the result of the recorded ggplot_fun function
 #' @param ggplot_expression A ggplot expression.
 #' @param strict An optional integer argument controlling the behavior of the record() function from chronicler. Default is 2.
 #' @return A chronicler object.

--- a/R/chronicle.R
+++ b/R/chronicle.R
@@ -614,9 +614,11 @@ check_diff <- function(.c, columns = c("ops_number", "function")){
 #' # This function is not meant to be used directly by the user.
 #' # Instead, use record_ggplot function.
 ggplot_fun <- function(ggplot_expression) {
+
   ggplot_obj <- eval_tidy(ggplot_expression)
   ggplot_build(ggplot_obj)
   return(ggplot_obj)
+
 }
 
 #' Record ggplot
@@ -631,6 +633,7 @@ ggplot_fun <- function(ggplot_expression) {
 #' @param strict An optional integer argument controlling the behavior of the record() function from chronicler. Default is 2.
 #' @return A chronicler object.
 #' @examples
+#' \dontrun{
 #' library(ggplot2)
 #' # Unsuccessful example
 #' x <- record_ggplot(ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpgg)))
@@ -639,10 +642,12 @@ ggplot_fun <- function(ggplot_expression) {
 #' # Successful example
 #' z <- record_ggplot(ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg)))
 #' print(z)
+#' }
 #' @export
 record_ggplot <- function(ggplot_expression, strict = 2) {
 
   r_ggplot_fun <- record(ggplot_fun, strict = strict)
   r_ggplot_fun(ggplot_expression)
+
 }
 

--- a/R/chronicle.R
+++ b/R/chronicle.R
@@ -613,7 +613,8 @@ check_diff <- function(.c, columns = c("ops_number", "function")){
 #' @examples
 #' # This function is not meant to be used directly by the user.
 #' # Instead, use record_ggplot function.
-ggplot_fun <- function(ggplot_call) {
+ggplot_fun <- function(ggplot_expression) {
+  ggplot_call <- substitute(ggplot_expression)
   ggplot_obj <- eval_tidy(ggplot_call)
   ggplot_build(ggplot_obj)
   return(ggplot_obj)
@@ -640,8 +641,8 @@ ggplot_fun <- function(ggplot_call) {
 #' print(z)
 #' @export
 record_ggplot <- function(ggplot_expression, strict = 2) {
-  ggplot_call <- substitute(ggplot_expression)
+  # ggplot_call <- substitute(ggplot_expression)
   r_ggplot_fun <- record(ggplot_fun, strict = strict)
-  r_ggplot_fun(ggplot_call)
+  r_ggplot_fun(ggplot_expression)
 }
 

--- a/R/chronicle.R
+++ b/R/chronicle.R
@@ -631,6 +631,7 @@ ggplot_fun <- function(ggplot_expression) {
 #' @param strict An optional integer argument controlling the behavior of the record() function from chronicler. Default is 2.
 #' @return A chronicler object.
 #' @examples
+#' library(ggplot2)
 #' # Unsuccessful example
 #' x <- record_ggplot(ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpgg)))
 #' print(x)

--- a/man/ggplot_fun.Rd
+++ b/man/ggplot_fun.Rd
@@ -4,27 +4,26 @@
 \alias{ggplot_fun}
 \title{Helper function for record_ggplot()}
 \usage{
-ggplot_fun(ggplot_call)
+ggplot_fun(ggplot_expression)
 }
 \arguments{
-\item{ggplot_call}{An unevaluated ggplot expression.}
+\item{ggplot_expression}{An unevaluated ggplot expression.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Helper function for record_ggplot()
-}
-\details{
-ggplot_fun() takes a ggplot_call (an unevaluated ggplot expression) as input
+ggplot_fun() takes a ggplot_expression (an unevaluated ggplot expression) as input
 and does the following steps:
 \enumerate{
-\item Evaluates the ggplot_call using rlang::eval_tidy
+\item Evaluates the ggplot_expression using rlang::eval_tidy
 \item Builds the ggplot object using ggplot2::ggplot_build
 \item Returns the ggplot object
 }
 }
 \examples{
+\dontrun{
 # This function is not meant to be used directly by the user.
 # Instead, use record_ggplot function.
+}
 }

--- a/man/record_ggplot.Rd
+++ b/man/record_ggplot.Rd
@@ -15,18 +15,16 @@ record_ggplot(ggplot_expression, strict = 2)
 A chronicler object.
 }
 \description{
-Record ggplot
-}
-\details{
 record_ggplot takes a ggplot_expression and an optional strict argument as input and does the following steps:
 \enumerate{
-\item Captures the unevaluated ggplot_expression using substitute
 \item Records the ggplot_fun function with the given strict argument using the record function from chronicler
-\item Passes the captured ggplot_call to the recorded ggplot_fun function
+\item Passes the ggplot_expression to the recorded ggplot_fun function
 \item Returns the result of the recorded ggplot_fun function
 }
 }
 \examples{
+\dontrun{
+library(ggplot2)
 # Unsuccessful example
 x <- record_ggplot(ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpgg)))
 print(x)
@@ -34,4 +32,5 @@ print(x)
 # Successful example
 z <- record_ggplot(ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg)))
 print(z)
+}
 }

--- a/tests/testthat/test-record_ggplot.R
+++ b/tests/testthat/test-record_ggplot.R
@@ -1,4 +1,5 @@
 library(ggplot2)
+# trigger rerun
 
 # Test 1: Verify that record_ggplot returns a chronicle object
 test_that("record_ggplot returns a chronicle object", {

--- a/tests/testthat/test-record_ggplot.R
+++ b/tests/testthat/test-record_ggplot.R
@@ -9,7 +9,7 @@ test_that("record_ggplot returns a chronicle object", {
   # it's passed as an unevaluated expression. This expression is then evaluated within 'ggplot_fun' (in 'chronicler' package environment),
   # where 'gg_expr' doesn't exist. Using global assignment ensures 'gg_expr' exists in all parent environments,
   # hence accessible by 'ggplot_fun' when it tries to evaluate the expression. This won't be an issue for users running the code outside 'testthat'.
-  ggplot_expression <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
   gg_chronicle <- record_ggplot(gg_expr)
@@ -23,7 +23,7 @@ test_that("the chronicle object produced by record_ggplot contains a ggplot obje
 
   # Define the ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
   gg_chronicle <- record_ggplot(gg_expr)
@@ -40,7 +40,7 @@ test_that("record_ggplot returns expected ggplot recipe", {
 
   # Create a ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot using record_ggplot function
   gg_chronicle <- record_ggplot(gg_expr)
@@ -65,7 +65,7 @@ test_that("record_ggplot returns expected ggplot recipe", {
 
   # Define the ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <<- ggplot(data = mtcars) +
+  gg_expr <- ggplot(data = mtcars) +
     geom_point(aes(y = hp, x = mpg)) +
     scale_x_continuous(name = "Miles per gallon") +
     scale_y_continuous(name = "Horsepower") +
@@ -103,7 +103,7 @@ test_that("record_ggplot produces the same output as the original expression", {
 
   # Define the ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
   gg_chronicle <- record_ggplot(gg_expr)

--- a/tests/testthat/test-record_ggplot.R
+++ b/tests/testthat/test-record_ggplot.R
@@ -1,5 +1,4 @@
 library(ggplot2)
-# trigger rerun
 
 # Test 1: Verify that record_ggplot returns a chronicle object
 test_that("record_ggplot returns a chronicle object", {

--- a/tests/testthat/test-record_ggplot.R
+++ b/tests/testthat/test-record_ggplot.R
@@ -9,7 +9,7 @@ test_that("record_ggplot returns a chronicle object", {
   # it's passed as an unevaluated expression. This expression is then evaluated within 'ggplot_fun' (in 'chronicler' package environment),
   # where 'gg_expr' doesn't exist. Using global assignment ensures 'gg_expr' exists in all parent environments,
   # hence accessible by 'ggplot_fun' when it tries to evaluate the expression. This won't be an issue for users running the code outside 'testthat'.
-  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  ggplot_expression <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
   gg_chronicle <- record_ggplot(gg_expr)
@@ -23,7 +23,7 @@ test_that("the chronicle object produced by record_ggplot contains a ggplot obje
 
   # Define the ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
   gg_chronicle <- record_ggplot(gg_expr)
@@ -40,7 +40,7 @@ test_that("record_ggplot returns expected ggplot recipe", {
 
   # Create a ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot using record_ggplot function
   gg_chronicle <- record_ggplot(gg_expr)
@@ -65,7 +65,7 @@ test_that("record_ggplot returns expected ggplot recipe", {
 
   # Define the ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <- ggplot(data = mtcars) +
+  gg_expr <<- ggplot(data = mtcars) +
     geom_point(aes(y = hp, x = mpg)) +
     scale_x_continuous(name = "Miles per gallon") +
     scale_y_continuous(name = "Horsepower") +
@@ -103,7 +103,7 @@ test_that("record_ggplot produces the same output as the original expression", {
 
   # Define the ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
   gg_chronicle <- record_ggplot(gg_expr)

--- a/tests/testthat/test-record_ggplot.R
+++ b/tests/testthat/test-record_ggplot.R
@@ -9,7 +9,7 @@ test_that("record_ggplot returns a chronicle object", {
   # it's passed as an unevaluated expression. This expression is then evaluated within 'ggplot_fun' (in 'chronicler' package environment),
   # where 'gg_expr' doesn't exist. Using global assignment ensures 'gg_expr' exists in all parent environments,
   # hence accessible by 'ggplot_fun' when it tries to evaluate the expression. This won't be an issue for users running the code outside 'testthat'.
-  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
   gg_chronicle <- record_ggplot(gg_expr)
@@ -23,7 +23,7 @@ test_that("the chronicle object produced by record_ggplot contains a ggplot obje
 
   # Define the ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
   gg_chronicle <- record_ggplot(gg_expr)
@@ -40,7 +40,7 @@ test_that("record_ggplot returns expected ggplot recipe", {
 
   # Create a ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot using record_ggplot function
   gg_chronicle <- record_ggplot(gg_expr)
@@ -65,7 +65,7 @@ test_that("record_ggplot returns expected ggplot recipe", {
 
   # Define the ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <<- ggplot(data = mtcars) +
+  gg_expr <- ggplot(data = mtcars) +
     geom_point(aes(y = hp, x = mpg)) +
     scale_x_continuous(name = "Miles per gallon") +
     scale_y_continuous(name = "Horsepower") +
@@ -103,7 +103,7 @@ test_that("record_ggplot produces the same output as the original expression", {
 
   # Define the ggplot expression
   # Global assignment explained in Test 1
-  gg_expr <<- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
+  gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
   gg_chronicle <- record_ggplot(gg_expr)

--- a/tests/testthat/test-record_ggplot.R
+++ b/tests/testthat/test-record_ggplot.R
@@ -4,11 +4,6 @@ library(ggplot2)
 test_that("record_ggplot returns a chronicle object", {
 
   # Define the ggplot expression
-  # We use global assignment (<<-) due to environment handling by 'testthat' and 'chronicler'
-  # 'testthat' creates a new environment for each test. However, when we pass 'gg_expr' to 'record_ggplot',
-  # it's passed as an unevaluated expression. This expression is then evaluated within 'ggplot_fun' (in 'chronicler' package environment),
-  # where 'gg_expr' doesn't exist. Using global assignment ensures 'gg_expr' exists in all parent environments,
-  # hence accessible by 'ggplot_fun' when it tries to evaluate the expression. This won't be an issue for users running the code outside 'testthat'.
   gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
@@ -22,7 +17,6 @@ test_that("record_ggplot returns a chronicle object", {
 test_that("the chronicle object produced by record_ggplot contains a ggplot object", {
 
   # Define the ggplot expression
-  # Global assignment explained in Test 1
   gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object
@@ -39,7 +33,6 @@ test_that("the chronicle object produced by record_ggplot contains a ggplot obje
 test_that("record_ggplot returns expected ggplot recipe", {
 
   # Create a ggplot expression
-  # Global assignment explained in Test 1
   gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot using record_ggplot function
@@ -64,7 +57,6 @@ test_that("record_ggplot returns expected ggplot recipe", {
 test_that("record_ggplot returns expected ggplot recipe", {
 
   # Define the ggplot expression
-  # Global assignment explained in Test 1
   gg_expr <- ggplot(data = mtcars) +
     geom_point(aes(y = hp, x = mpg)) +
     scale_x_continuous(name = "Miles per gallon") +
@@ -102,7 +94,6 @@ test_that("record_ggplot returns expected ggplot recipe", {
 test_that("record_ggplot produces the same output as the original expression", {
 
   # Define the ggplot expression
-  # Global assignment explained in Test 1
   gg_expr <- ggplot(data = mtcars) + geom_point(aes(y = hp, x = mpg))
 
   # Record the ggplot expression and store the chronicle object


### PR DESCRIPTION
Turns out substitute() wasn't necessary after all. :) Adjusted documentation as well. 